### PR TITLE
Fix #4: Editor not clickable on placeholder

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -12,7 +12,11 @@ export function LexicalEditor({ config }: LexicalEditorProps) {
     <LexicalComposer initialConfig={config}>
       <RichTextPlugin
         contentEditable={<ContentEditable />}
-        placeholder={<div className='absolute top-[1.125rem] left-[1.125rem] opacity-50'>Start writing ...</div>}
+        placeholder={
+          <div className='absolute top-[1.125rem] left-[1.125rem] opacity-50 pointer-events-none'>
+            Start writing ...
+          </div>
+        }
         ErrorBoundary={LexicalErrorBoundary}
       />
     </LexicalComposer>


### PR DESCRIPTION
fix #4 

### Changes
- Add `pointer-events-none` (ref: [pointer-events](https://tailwindcss.com/docs/pointer-events#controlling-pointer-event-behavior)) 