### PR TITLE
Support markdown

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -8,7 +8,8 @@ import { LocalStoragePlugin } from './plugins/LocalStorage';
 import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin';
 import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin';
-import { TRANSFORMERS, CODE } from '@lexical/markdown';
+import { TRANSFORMERS, CODE, INLINE_CODE } from '@lexical/markdown';
+import AutoLinkPlugin from './plugins/AutoLink';
 
 interface LexicalEditorProps {
   config: InitialConfigType;
@@ -27,9 +28,10 @@ function LexicalEditor({ config }: LexicalEditorProps) {
         ErrorBoundary={LexicalErrorBoundary}
       />
       <LocalStoragePlugin namespace={config.namespace} />
-      <MarkdownShortcutPlugin transformers={TRANSFORMERS.filter(t => t !== CODE)} />
+      <MarkdownShortcutPlugin transformers={TRANSFORMERS.filter(t => t !== CODE && t !== INLINE_CODE)} />
       <LinkPlugin />
       <ListPlugin />
+      <AutoLinkPlugin />
     </LexicalComposer>
   );
 }

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1,8 +1,14 @@
 import { InitialConfigType, LexicalComposer } from '@lexical/react/LexicalComposer';
-import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
+import TooltipNodes from './nodes/TooltipNodes';
+
+import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { LocalStoragePlugin } from './plugins/LocalStorage';
+import { ListPlugin } from '@lexical/react/LexicalListPlugin';
+import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin';
+import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin';
+import { TRANSFORMERS, CODE } from '@lexical/markdown';
 
 interface LexicalEditorProps {
   config: InitialConfigType;
@@ -21,10 +27,14 @@ function LexicalEditor({ config }: LexicalEditorProps) {
         ErrorBoundary={LexicalErrorBoundary}
       />
       <LocalStoragePlugin namespace={config.namespace} />
+      <MarkdownShortcutPlugin transformers={TRANSFORMERS.filter(t => t !== CODE)} />
+      <LinkPlugin />
+      <ListPlugin />
     </LexicalComposer>
   );
 }
 
+const EDITORS_NODES = [...TooltipNodes];
 const EDITOR_NAMESPACE = 'lexical-editor';
 
 export function Editor() {
@@ -39,6 +49,7 @@ export function Editor() {
         config={{
           namespace: EDITOR_NAMESPACE,
           editorState: content,
+          nodes: EDITORS_NODES,
           theme: {
             root: 'p-4 border-slate-500 border-2 rounded h-full min-h-[200px] focus:outline-none focus-visible:border-black',
             link: 'cursor-pointer',
@@ -48,6 +59,10 @@ export function Editor() {
               italic: 'italic',
               strikethrough: 'line-through',
               underlineStrikethrough: 'underlined-line-through',
+            },
+            list: {
+              listitem: '',
+              // TODO: nested, ol, ul, ...
             },
           },
           onError: error => {

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -7,9 +7,8 @@ import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { LocalStoragePlugin } from './plugins/LocalStorage';
 import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin';
-import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin';
-import { TRANSFORMERS, CODE, INLINE_CODE } from '@lexical/markdown';
 import AutoLinkPlugin from './plugins/AutoLink';
+import MarkdownShortcutPlugin from './plugins/MarkdownShortcut';
 
 interface LexicalEditorProps {
   config: InitialConfigType;
@@ -28,7 +27,7 @@ function LexicalEditor({ config }: LexicalEditorProps) {
         ErrorBoundary={LexicalErrorBoundary}
       />
       <LocalStoragePlugin namespace={config.namespace} />
-      <MarkdownShortcutPlugin transformers={TRANSFORMERS.filter(t => t !== CODE && t !== INLINE_CODE)} />
+      <MarkdownShortcutPlugin />
       <LinkPlugin />
       <ListPlugin />
       <AutoLinkPlugin />

--- a/src/components/Editor/nodes/TooltipNodes.ts
+++ b/src/components/Editor/nodes/TooltipNodes.ts
@@ -1,0 +1,17 @@
+import type { Klass, LexicalNode } from 'lexical';
+
+import { LinkNode, AutoLinkNode } from '@lexical/link';
+import { ListNode, ListItemNode } from '@lexical/list';
+import { HeadingNode, QuoteNode } from '@lexical/rich-text';
+
+const TooltipNodes: Array<Klass<LexicalNode>> = [
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  LinkNode,
+  AutoLinkNode,
+  // HorizontalRuleNode,
+];
+
+export default TooltipNodes;

--- a/src/components/Editor/plugins/AutoLink.tsx
+++ b/src/components/Editor/plugins/AutoLink.tsx
@@ -1,0 +1,22 @@
+// https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/plugins/AutoLinkPlugin/index.tsx
+
+import { AutoLinkPlugin, createLinkMatcherWithRegExp } from '@lexical/react/LexicalAutoLinkPlugin';
+
+const URL_REGEX =
+  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
+
+const EMAIL_REGEX =
+  /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
+
+const MATCHERS = [
+  createLinkMatcherWithRegExp(URL_REGEX, text => {
+    return text.startsWith('http') ? text : `https://${text}`;
+  }),
+  createLinkMatcherWithRegExp(EMAIL_REGEX, text => {
+    return `mailto:${text}`;
+  }),
+];
+
+export default function LexicalAutoLinkPlugin(): JSX.Element {
+  return <AutoLinkPlugin matchers={MATCHERS} />;
+}

--- a/src/components/Editor/plugins/MarkdownShortcut.tsx
+++ b/src/components/Editor/plugins/MarkdownShortcut.tsx
@@ -1,0 +1,10 @@
+import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin';
+import { TRANSFORMERS, CODE, INLINE_CODE } from '@lexical/markdown';
+import { removeElements } from '../../../utils/removeElements';
+
+const NO_USE = [CODE, INLINE_CODE];
+const CUSTOM_TRANSFORMERS = removeElements(TRANSFORMERS, NO_USE);
+
+export default function LexicalMarkdownShortcutPlugin() {
+  return <MarkdownShortcutPlugin transformers={CUSTOM_TRANSFORMERS} />;
+}

--- a/src/utils/removeElements.ts
+++ b/src/utils/removeElements.ts
@@ -1,0 +1,4 @@
+export function removeElements<T>(sourceArray: Array<T>, elementsToRemove: Array<T>) {
+  const setToRemove = new Set(elementsToRemove);
+  return sourceArray.filter(v => !setToRemove.has(v));
+}


### PR DESCRIPTION
### Changes
- add `MarkdownShorcutPlugin` to support markdown for [TRANSFORMERS](https://github.com/facebook/lexical/blob/5c7f1b90044c64aa2373104e9ac1aa7e58976a6d/packages/lexical-markdown/src/index.ts#L66) except `CODE`, `INLINE_CODE`