### PR TITLE
Store EditorState as html

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -4,7 +4,7 @@ import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import TooltipNodes from './nodes/TooltipNodes';
 
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
-import { LocalStoragePlugin } from './plugins/LocalStorage';
+import { LocalStoragePlugin, retrieveContent } from './plugins/LocalStorage';
 import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin';
 import { AutoLinkPlugin } from './plugins/AutoLink';
@@ -46,8 +46,6 @@ const EDITORS_NODES = [...TooltipNodes];
 const EDITOR_NAMESPACE = 'lexical-editor';
 
 export function Editor() {
-  const content = localStorage.getItem(EDITOR_NAMESPACE);
-
   return (
     <div
       id='editor-wrapper'
@@ -57,7 +55,7 @@ export function Editor() {
         <LexicalEditor
           config={{
             namespace: EDITOR_NAMESPACE,
-            editorState: content,
+            editorState: retrieveContent(EDITOR_NAMESPACE),
             nodes: EDITORS_NODES,
             theme: {
               root: 'p-4 border-slate-500 border-2 rounded h-full min-h-[200px] focus:outline-none focus-visible:border-black',

--- a/src/components/Editor/plugins/LocalStorage.tsx
+++ b/src/components/Editor/plugins/LocalStorage.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $generateHtmlFromNodes, $generateNodesFromDOM } from '@lexical/html';
+import { EditorState, LexicalEditor, $getRoot, $insertNodes } from 'lexical';
+import { InitialEditorStateType } from '@lexical/react/LexicalComposer';
 
 interface LocalStoragePluginProps {
   namespace: string;
@@ -15,15 +18,39 @@ export function LocalStoragePlugin({ namespace }: LocalStoragePluginProps) {
     [namespace]
   );
 
+  // serialize to html
+  const serializeState = useCallback(
+    (editorState: EditorState) => {
+      return editorState.read(() => $generateHtmlFromNodes(editor, null));
+    },
+    [editor]
+  );
+
   useEffect(() => {
     return editor.registerUpdateListener(({ dirtyElements, dirtyLeaves, editorState }) => {
       // Don't update if nothing has changed
       if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
 
-      const serializedState = JSON.stringify(editorState);
-      saveContent(serializedState); // TODO: need to be debounced when it fetches APIs
+      const serializedState = serializeState(editorState);
+      saveContent(serializedState); // TODO: need to be debounced
     });
-  }, [editor, saveContent]);
+  }, [editor, saveContent, serializeState]);
 
   return null;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function retrieveContent(namespace: string): InitialEditorStateType {
+  const content = localStorage.getItem(namespace);
+  if (!content) return null;
+
+  // html to EditorState
+  return function deserializeState(editor: LexicalEditor) {
+    const parser = new DOMParser();
+    const dom = parser.parseFromString(content, 'text/html');
+    const nodes = $generateNodesFromDOM(editor, dom);
+
+    $getRoot().select();
+    $insertNodes(nodes);
+  };
 }


### PR DESCRIPTION
### Changes
- store EditorState as html string on external storage (for now `localStorage`)
- It would be better to handle editorState as html considering SSR or to be exported to an e-mail